### PR TITLE
fix: rewrite ci-container-test workflow

### DIFF
--- a/.github/workflows/ci-container-test.yaml
+++ b/.github/workflows/ci-container-test.yaml
@@ -1,6 +1,16 @@
 ---
-name: ci-registry-clean
-# This action is ment to clean up all the old docker tags base on build #
+name: ci-container-test
+# Reusable workflow that validates a published container image by running its
+# built-in test suite (/usr/bin/container-test).
+#
+# How it works:
+#   1. Pull the :dev image from the registry
+#   2. Start the container in detached mode so s6 services initialise normally
+#   3. Execute /usr/bin/container-test inside the running container
+#      - container-test is a symlink to container-health, which runs every
+#        script in /etc/container/health.d/ and returns 0 only if all pass
+#   4. Stop and remove the container regardless of test outcome (trap EXIT)
+#   5. Fail the workflow if container-test exited non-zero
 
 on:
   workflow_call:
@@ -22,31 +32,71 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
+        # Check out the calling repository so pwd-derived names resolve correctly
         uses: actions/checkout@v4
 
+      - name: Install Tools
+        # Install podman for container lifecycle management.
+        # Installed explicitly here (as in ci-podman-build.yaml) rather than
+        # relying on runner pre-installation to ensure a known, consistent version.
+        run: |
+          sudo /usr/bin/apt-get update
+          sudo /usr/bin/apt-get install --yes podman
+
       - name: Registry Login
+        # Authenticate to the registry so the pull step can access private images
         run: |
           echo "${{ secrets.REGISTRY_TOKEN }}" | /usr/bin/podman login \
             --username "${{ secrets.REGISTRY_USERNAME }}" \
             --password-stdin ${{ inputs.registry_name }}
 
       - name: "Pull Container Image"
+        # Pull the :dev tag that was published by the preceding ci-podman-publish job.
+        # Pulling explicitly before run gives a clearer error message on pull failure
+        # and avoids mixing pull output with test output.
         # yamllint disable rule:line-length
         run: |
           NS="${{ secrets.REGISTRY_USERNAME }}"
           REPO="$(pwd | awk -F'/' '{print $NF}')"
-          IMG="${NS}/${REPO}:dev"
+          IMG="${{ inputs.registry_name }}/${NS}/${REPO}:dev"
           /usr/bin/podman pull "${IMG}"
         # yamllint enable rule:line-length
 
       - name: "Test Container"
+        # Start the container, run its built-in test suite, then clean up.
+        #
+        # Cleanup strategy: a bash trap on EXIT ensures podman stop + rm -f
+        # are called on every exit path (pass, fail, or signal).  The || true
+        # guards prevent a cleanup failure from masking the real test exit code.
+        #
+        # Why no --rm: using --rm with --detach would auto-remove the container
+        # on stop, but provides no guarantee of cleanup if the exec step fails
+        # before stop is reached.  Manual trap is more reliable.
         run: |
-          # Need to somehow deal with volumes
-          set -xe
-          touch .env
           REPO="$(pwd | awk -F'/' '{print $NF}')"
-          /usr/bin/podman run --env-file .env --detach --name "${REPO}" \
-                              --publish 8080:8080 --rm \
-                             "docker.io/gautada/${REPO}:dev"
-          /usr/bin/podman stop "${REPO}"
-          set +xe
+          IMG="${{ inputs.registry_name }}/${{ secrets.REGISTRY_USERNAME }}/${REPO}:dev"
+
+          # Ensure .env exists (may be empty); podman requires the file to be present
+          touch .env
+
+          # Start the container in detached mode; s6-svscan initialises services
+          /usr/bin/podman run \
+            --env-file .env \
+            --detach \
+            --name "${REPO}" \
+            "${IMG}"
+
+          # Register cleanup to run on any exit — pass, fail, or signal
+          cleanup() {
+            /usr/bin/podman stop "${REPO}" || true
+            /usr/bin/podman rm -f "${REPO}" || true
+          }
+          trap cleanup EXIT
+
+          # Wait for s6 service supervisor to finish initialising container processes
+          sleep 5
+
+          # Run the container test suite.
+          # /usr/bin/container-test is a symlink to container-health, which
+          # iterates /etc/container/health.d/ and returns 0 only if all checks pass.
+          /usr/bin/podman exec "${REPO}" /usr/bin/container-test


### PR DESCRIPTION
## Summary

Fixes #9

Complete rewrite of `.github/workflows/ci-container-test.yaml` to correctly instantiate a container, execute its built-in test suite, guarantee cleanup, and propagate failures to the CI run.

---

## Changes

### 1. Fix workflow name
`name: ci-registry-clean` → `name: ci-container-test` (copy-paste artifact from an unrelated workflow)

### 2. Add inline documentation
Top-level workflow comment explains the full lifecycle. Each step has a comment explaining what it does and why.

### 3. Add podman install step
Consistent with `ci-podman-build.yaml` — installs podman explicitly rather than assuming runner availability:
```yaml
- name: Install Tools
  run: |
    sudo /usr/bin/apt-get update
    sudo /usr/bin/apt-get install --yes podman
```

### 4. Rewrite "Test Container" step
**Before:** starts container, stops it — no test ever runs, exit code ignored.

**After:**
```bash
# Start detached (no --rm; cleanup handled by trap)
podman run --env-file .env --detach --name "${REPO}" "${IMG}"

# Guaranteed cleanup on any exit path
cleanup() { podman stop "${REPO}" || true; podman rm -f "${REPO}" || true; }
trap cleanup EXIT

# Wait for s6 to initialise services
sleep 5

# Run health/test suite — exits non-zero if any check fails
podman exec "${REPO}" /usr/bin/container-test
```

### 5. Minor: fix Pull step image reference
Was: `${NS}/${REPO}:dev` (missing registry prefix) → `${{ inputs.registry_name }}/${NS}/${REPO}:dev`

---

## How `/usr/bin/container-test` works

In all `gautada/*` containers (based on `gautada/debian`):
- `/usr/bin/container-test` → symlink to `/usr/bin/container-health`
- `container-health` iterates `/etc/container/health.d/` and runs each script
- Returns **0** if all pass, **non-zero** if any fail

---

## Acceptance Criteria

- [x] Workflow `name` corrected to `ci-container-test`
- [x] Each step has inline YAML comments
- [x] Podman install step present before Registry Login
- [x] Container started detached without `--rm`
- [x] `trap cleanup EXIT` ensures stop + rm -f on all exit paths
- [x] `/usr/bin/container-test` called via `podman exec`
- [x] Workflow fails if `container-test` exits non-zero
- [ ] End-to-end validated in consumer pipeline (e.g., `gautada/debian`) — pending merge + CI run

## Risk

Low — workflow is only invoked via `workflow_call`; no existing callers are broken by this change.