### PR TITLE
docs: document sqlfluff and jscpd

### DIFF
--- a/.jscpd.json
+++ b/.jscpd.json
@@ -1,3 +1,12 @@
 {
-  "threashold": 15
+  "threshold": 15,
+  "minTokens": 50,
+  "minLines": 5,
+  "reporters": ["console"],
+  "ignore": [
+    "dist/**",
+    "build/**",
+    "**/*.min.*",
+    "**/*.generated.*"
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -9,6 +9,41 @@ Included are are configurations for the tools to execute linting on commit.
 
 ### pre-commit
 
+### sqlfluff
+
+Install with pipx or Homebrew:
+
+```sh
+pipx install sqlfluff
+# or
+brew install sqlfluff
+```
+
+The repo ships a default `.sqlfluff` (Postgres dialect). Run the linter manually
+with:
+
+```sh
+sqlfluff lint .
+```
+
+### jscpd
+
+[jscpd](https://github.com/kucherenko/jscpd) requires Node.js. Install Node (for
+example, `brew install node`) and then install the CLI:
+
+```sh
+npm install -g jscpd
+```
+
+Configuration lives in `.jscpd.json`. To scan locally:
+
+```sh
+jscpd --config .jscpd.json
+```
+
+Both tools are wired into `.pre-commit-config.yaml`, so `pre-commit run
+--all-files` executes them automatically.
+
 #### Install
 
 To install on the system for MacOS


### PR DESCRIPTION
## Summary
- flesh out `.jscpd.json` (correct threshold spelling + ignore patterns)
- extend the README with install/run instructions for sqlfluff and jscpd, including the note about Node for jscpd
- confirmed the updated README passes `markdownlint`

## Testing
- `pre-commit run --all-files`
