### PR TITLE
Fix: Super-linter script errors (Issue #5)

### DIFF
--- a/.github/workflows/ci-linter.yaml
+++ b/.github/workflows/ci-linter.yaml
@@ -32,6 +32,8 @@ jobs:
           OUTPUT_DETAILS: detailed
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LINTER_RULES_PATH: .
+          # GITHUB_STATUS_API: false disables reporting status to GitHub (fixes 403 errors when token is read-only)
+          GITHUB_STATUS_API: false
           # VALIDATE_BASH: true
           FILTER_REGEX_EXCLUDE: '.*\.zsh$'
           DOCKERFILE_HADOLINT_FILE_NAME: .hadolint.yaml


### PR DESCRIPTION
Disables the GitHub Status API in the super-linter workflow to resolve 403 Forbidden errors when the GITHUB_TOKEN lacks sufficient permissions to post status updates. Super-linter already reports success/failure via the job exit code. \n\nAC status:\n- [x] GITHUB_STATUS_API set to false [Develop]\n\nRisk: Low\nCI: Pending\n\nHanding off to integration stage.