### PR TITLE
Fix: use checkout@v4

### DIFF
--- a/.github/workflows/ci-container-test.yaml
+++ b/.github/workflows/ci-container-test.yaml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - name: Checkout
         # Check out the calling repository so pwd-derived names resolve correctly
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
 
       - name: Install Tools
         # Install podman for container lifecycle management.

--- a/.github/workflows/ci-deep-scan.yaml
+++ b/.github/workflows/ci-deep-scan.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
 
       # --- Semgrep (language-agnostic SAST) ---
       - name: Semgrep SAST

--- a/.github/workflows/ci-linter.yaml
+++ b/.github/workflows/ci-linter.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci-podman-build.yaml
+++ b/.github/workflows/ci-podman-build.yaml
@@ -44,7 +44,7 @@ jobs:
     # yamllint enable rule:line-length
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
 
       # - name: Export .args to GITHUB_ENV (if present)
       #   if: ${{ hashFiles(inputs.args_file) != '' }}

--- a/.github/workflows/ci-podman-publish.yaml
+++ b/.github/workflows/ci-podman-publish.yaml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
 
       - name: Registry Login
         run: |

--- a/.github/workflows/ci-registry-clean.yaml
+++ b/.github/workflows/ci-registry-clean.yaml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
 
       - name: "Clean Excess and Unlinked Tags"
         # yamllint disable rule:line-length


### PR DESCRIPTION
Fixes startup failure in downstream builds caused by actions/checkout@v5 which does not exist.